### PR TITLE
Update CLAUDE.md with correct hook names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The repository has a minimal structure focused on providing pre-commit hook defi
 
 - `.pre-commit-hooks.yaml` - Defines available hooks for use by other projects
 - Currently provides two hooks:
-  - `mix-format-check`: Validates Elixir code formatting
+  - `mix-format`: Formats Elixir files with mix format
   - `mix-credo`: Runs Credo static analysis in strict mode
 
 ## Development Notes


### PR DESCRIPTION
## Summary
- Update hook names in CLAUDE.md to match actual implementation in .pre-commit-hooks.yaml
- Changed `mix-format-check` to `mix-format` to reflect that it auto-formats files
- Keep `mix-credo` unchanged as it correctly describes the hook

## Test plan
- [x] Verified hook names match .pre-commit-hooks.yaml
- [x] Documentation accurately describes hook behavior

🤖 Generated with [Claude Code](https://claude.ai/code)